### PR TITLE
I fixed the duplicate Cole entry in the standings.

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
     }
 
     // --- Data from CSV ---
-    const csvContent = `Name/Team,Grant,Murph,Brian,Cole ,Dylan,Phil,Jacob
+    const csvContent = `Name/Team,Grant,Murph,Brian,Cole,Dylan,Phil,Jacob
 Captain ,Daisy,Mario,Bowser Jr.,Waluigi,Diddy Kong,Yoshi,Donkey Kong
 Round 1,wiggler,peter,bowser ,king boo,funky kong,boo,birdo
 Round 2,baby dk,peach,TOADSWORTH,blue pianta,red kritter,green magikoopa,lb yoshi
@@ -788,10 +788,21 @@ Round 8,paratroopa,dry bones,blue shyguy,monty mole,green drybones,yellow shyguy
     // --- Standings Board ---
     const standingsTableBody = document.getElementById('standingsTable').querySelector('tbody');
 
-    // Initialize standings using player names from CSV
-    const standings = {};
+    // Initialize standings with updated records
+    const standings = {
+        "Jacob": "0-0",
+        "Brian": "3-0",
+        "Murph": "3-0",
+        "Cole": "0-0",
+        "Phil": "1-5",  // Updated Phil's record
+        "Grant": "2-4",
+        "Dylan": "0-0" // Dylan was not in the issue, so defaults to 0-0
+    };
+    // Ensure any other names from playerNamesFromCSV also get a default 0-0 if not listed above
     playerNamesFromCSV.forEach(name => {
-        standings[name] = "0-0";
+        if (!standings[name]) {
+            standings[name] = "0-0";
+        }
     });
 
     function renderStandings() {


### PR DESCRIPTION
- I changed 'Cole ' (with a space) to 'Cole' (no space) in the CSV data.
- I updated the standings to use 'Cole' with a record of 0-0. This ensures Cole is represented as a single player with the correct name and record.