### PR TITLE
Fix: Clean up CSS and JavaScript artifacts to resolve potential errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,70 +196,29 @@
     }
     /*
  update-draft-board
-    .delete-pick-btn {
-      background-color: #ffc107; 
-
-  update-draft-board
-    .delete-pick-btn {
-      background-color: #ffc107; 
     .delete-pick-btn { /* Style for draft pick delete button */
-    /*
       background-color: #ffc107; /* Yellowish color for delete pick */
-    /*
- main
- main
       color: #333;
       border: none;
       padding: 3px 6px;
       font-size: 0.65rem;
       border-radius: 3px;
       cursor: pointer;
- update-draft-board
-      transition: opacity 0.2s ease-in-out; 
-      margin-left: 5px;
-      vertical-align: middle; 
-      opacity: 0; 
-      pointer-events: none; 
-
-  update-draft-board
-      transition: opacity 0.2s ease-in-out; 
-      margin-left: 5px;
-      vertical-align: middle; 
-      opacity: 0; 
-      pointer-events: none; 
       transition: opacity 0.2s ease-in-out; /* Smooth transition for opacity */
-    /*
       margin-left: 5px;
       vertical-align: middle; /* Align with text */
-    /*
       opacity: 0; /* Hidden by default */
-    /*
       pointer-events: none; /* Make it unclickable when invisible */
-    /*
- main
- main
     }
     .delete-pick-btn:hover {
       background-color: #e0a800;
     }
-    */
- update-draft-board
-    /* 
-    Show delete button on hover over the table cell
-
- update-draft-board
-    /* 
-    Show delete button on hover over the table cell
 
     /* Show delete button on hover over the table cell */
-    /*
- main
- main
     #draftBoardTable td:hover .delete-pick-btn {
       opacity: 1; 
       pointer-events: auto; 
     }
-    */
 </style>
 </head>
 <body>
@@ -793,9 +752,7 @@ Round 8,paratroopa,dry bones,blue shyguy,monty mole,green drybones,yellow shyguy
         "Jacob": "0-0",
         "Brian": "3-0",
         "Murph": "3-0",
- update-phil-record
         "Cole": "0-0",
-      main
         "Phil": "1-5",  // Updated Phil's record
         "Grant": "2-4",
         "Dylan": "0-0" // Dylan was not in the issue, so defaults to 0-0


### PR DESCRIPTION
This change addresses an issue where the website's wheel functionality was reportedly "messed up," possibly due to errors related to the Standings Board.

Changes made:
- Removed duplicated and commented-out CSS rules for .delete-pick-btn.
- Removed CSS comments that appeared to be merge conflict markers (update-draft-board, main).
- Removed JavaScript comments in the 'standings' object that also appeared to be merge conflict markers (update-phil-record, main).

These cleanups are intended to prevent JavaScript errors that could have been halting script execution and affecting website functionality, including the wheels. Automated testing of the fix was inconclusive due to limitations in my current environment.