### PR TITLE
Update standings for Cole and Murph

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,8 +751,8 @@ Round 8,paratroopa,dry bones,blue shyguy,monty mole,green drybones,yellow shyguy
     const standings = {
         "Jacob": "0-0",
         "Brian": "3-0",
-        "Murph": "3-0",
-        "Cole": "0-0",
+        "Murph": "6-0",
+        "Cole": "0-3",
         "Phil": "1-5",  // Updated Phil's record
         "Grant": "2-4",
         "Dylan": "0-0" // Dylan was not in the issue, so defaults to 0-0


### PR DESCRIPTION
This commit updates the standings board in index.html.
- Cole's record is changed to 0-3.
- Murph's record is changed to 6-0.

The changes were made directly to the 'standings' JavaScript object, which is used to dynamically render the standings table.